### PR TITLE
Release of past reservations implemented

### DIFF
--- a/app/src/main/java/com/example/parkingsystem/activities/ParkingSpaceReservationActivity.java
+++ b/app/src/main/java/com/example/parkingsystem/activities/ParkingSpaceReservationActivity.java
@@ -30,6 +30,7 @@ public class ParkingSpaceReservationActivity extends AppCompatActivity implement
         binding.buttonParkingSpaceReservationPickerBegin.setOnClickListener(view -> presenter.onButtonParkingSpaceReservationPickerPressed(this));
         binding.buttonParkingSpaceReservationPickerEnd.setOnClickListener(view -> presenter.onButtonParkingSpaceReservationPickerPressed(this));
         binding.buttonParkingSpaceReservationSave.setOnClickListener(view -> presenter.onButtonParkingSpaceReservationSavePressed());
+        binding.buttonParkingSpaceReservationDelete.setOnClickListener(view -> presenter.onButtonParkingSpaceReservationDeletePressed());
     }
 
     @Override

--- a/app/src/main/java/com/example/parkingsystem/database/ParkingSpaceReservationDB.java
+++ b/app/src/main/java/com/example/parkingsystem/database/ParkingSpaceReservationDB.java
@@ -1,13 +1,16 @@
 package com.example.parkingsystem.database;
 
 import com.example.parkingsystem.entity.Reservation;
+import com.example.parkingsystem.utils.Constants;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ParkingSpaceReservationDB {
     private static ParkingSpaceReservationDB database = null;
-    HashMap<Integer, List<Reservation>> hashReservation = new HashMap<>();
+    Map<Integer, List<Reservation>> hashReservation = new HashMap<>();
 
     private ParkingSpaceReservationDB() {
 
@@ -20,7 +23,7 @@ public class ParkingSpaceReservationDB {
         return database;
     }
 
-    public HashMap<Integer, List<Reservation>> getHash() {
+    public Map<Integer, List<Reservation>> getHash() {
         return hashReservation;
     }
 
@@ -32,5 +35,19 @@ public class ParkingSpaceReservationDB {
         }
         reservations.add(reservation);
         hashReservation.put(parkingSpace, reservations);
+    }
+
+    public int releasePastReservations() {
+        int reservationsReleased = Constants.ZERO;
+        Calendar currentCalendar = Calendar.getInstance();
+        for (List<Reservation> reservationList : hashReservation.values()) {
+            for (int i = Constants.ZERO; i < reservationList.size(); i++) {
+                if (reservationList.get(i).getDateAndTimeEnd().before(currentCalendar)) {
+                    reservationList.remove(reservationList.get(i));
+                    reservationsReleased++;
+                }
+            }
+        }
+        return reservationsReleased;
     }
 }

--- a/app/src/main/java/com/example/parkingsystem/mvp/contracts/ParkingSpaceReservationContract.java
+++ b/app/src/main/java/com/example/parkingsystem/mvp/contracts/ParkingSpaceReservationContract.java
@@ -17,6 +17,8 @@ public interface ParkingSpaceReservationContract {
         void onDateSetPressed(int year, int month, int day, TimePickerDialog.OnTimeSetListener timeListener);
 
         void onTimeSetPressed(int hour, int time);
+
+        void onButtonParkingSpaceReservationDeletePressed();
     }
 
     interface ParkingSpaceReservationView {
@@ -32,21 +34,33 @@ public interface ParkingSpaceReservationContract {
 
         void showSaveDone();
 
-        int getParkingSpace();
+        String getParkingSpace();
 
-        int getSecurityCode();
+        String getSecurityCode();
 
-        void showMissingFieldMessage(ReservationVerificationResult reservationVerificationResult);
+        void showMissingDateStart();
+
+        void showMissingTimeStart();
+
+        void showMissingDateEnd();
+
+        void showMissingTimeEnd();
+
+        void showMissingParkingSpace();
+
+        void showMissingSecurityCode();
+
+        void showReservationOverlapping();
 
         Button getButtonPickerStart();
+
+        void showReleasedPastReservations(int amountReservations);
 
     }
 
     interface ParkingSpaceReservationModel {
 
-        void makeReservation();
-
-        ReservationVerificationResult checkFields(Reservation reservation);
+        ReservationVerificationResult checkFields();
 
         Reservation getReservation();
 
@@ -56,6 +70,25 @@ public interface ParkingSpaceReservationContract {
 
         void setDateStartButtonPressed(boolean isDateStartButtonPressed);
 
-        boolean isPressed(Button btn);
+        void makeReservation(Reservation reservation);
+
+        int releaseReservations();
+
+        Calendar getDateStart();
+
+        Calendar getTimeStart();
+
+        Calendar getDateEnd();
+
+        Calendar getTimeEnd();
+
+        void setDateStart(Calendar dateStart);
+
+        void setTimeStart(Calendar timeStart);
+
+        void setDateEnd(Calendar dateEnd);
+
+        void setTimeEnd(Calendar timeEnd);
+
     }
 }

--- a/app/src/main/java/com/example/parkingsystem/mvp/model/ParkingSpaceReservationModel.java
+++ b/app/src/main/java/com/example/parkingsystem/mvp/model/ParkingSpaceReservationModel.java
@@ -1,12 +1,12 @@
 package com.example.parkingsystem.mvp.model;
 
-import android.widget.Button;
 import com.example.parkingsystem.database.ParkingSpaceReservationDB;
 import com.example.parkingsystem.entity.Reservation;
 import com.example.parkingsystem.mvp.contracts.ParkingSpaceReservationContract;
 import com.example.parkingsystem.utils.Constants;
 import com.example.parkingsystem.utils.ReservationVerification;
 import com.example.parkingsystem.utils.ReservationVerificationResult;
+import java.util.Calendar;
 
 public class ParkingSpaceReservationModel implements ParkingSpaceReservationContract.ParkingSpaceReservationModel {
     private Reservation reservation = new Reservation();
@@ -20,6 +20,46 @@ public class ParkingSpaceReservationModel implements ParkingSpaceReservationCont
     }
 
     @Override
+    public Calendar getDateStart() {
+        return reservation.getDateStart();
+    }
+
+    @Override
+    public Calendar getTimeStart() {
+        return reservation.getTimeStart();
+    }
+
+    @Override
+    public Calendar getDateEnd() {
+        return reservation.getDateEnd();
+    }
+
+    @Override
+    public Calendar getTimeEnd() {
+        return reservation.getTimeEnd();
+    }
+
+    @Override
+    public void setDateStart(Calendar dateStart) {
+        reservation.setDateStart(dateStart);
+    }
+
+    @Override
+    public void setTimeStart(Calendar timeStart) {
+        reservation.setTimeStart(timeStart);
+    }
+
+    @Override
+    public void setDateEnd(Calendar dateEnd) {
+        reservation.setDateEnd(dateEnd);
+    }
+
+    @Override
+    public void setTimeEnd(Calendar timeEnd) {
+        reservation.setTimeEnd(timeEnd);
+    }
+
+    @Override
     public boolean getDateStartButtonPressed() {
         return isDateStartButtonPressed;
     }
@@ -30,13 +70,18 @@ public class ParkingSpaceReservationModel implements ParkingSpaceReservationCont
     }
 
     @Override
-    public boolean isPressed(Button btn) {
-        return btn.isPressed();
+    public Reservation getReservation() {
+        return reservation;
     }
 
     @Override
-    public Reservation getReservation() {
-        return reservation;
+    public void makeReservation(Reservation reservation) {
+        database.addReservation(reservation);
+    }
+
+    @Override
+    public int releaseReservations() {
+        return database.releasePastReservations();
     }
 
     @Override
@@ -46,12 +91,7 @@ public class ParkingSpaceReservationModel implements ParkingSpaceReservationCont
     }
 
     @Override
-    public void makeReservation() {
-        database.addReservation(reservation);
-    }
-
-    @Override
-    public ReservationVerificationResult checkFields(Reservation reservation) {
+    public ReservationVerificationResult checkFields() {
         if (getReservation().getDateStart() == null) {
             return ReservationVerificationResult.MISSING_DATE_START;
         }
@@ -70,10 +110,9 @@ public class ParkingSpaceReservationModel implements ParkingSpaceReservationCont
         if (getReservation().getSecurityCode() == Constants.NUMBER_MINUS_ONE) {
             return ReservationVerificationResult.MISSING_SECURITY_CODE;
         }
-        if (!verification.canBeReserved(reservation)) {
+        if (!verification.canBeReserved(getReservation())) {
             return ReservationVerificationResult.RESERVATION_OVERLAPPING;
         }
         return ReservationVerificationResult.SUCCESS;
-
     }
 }

--- a/app/src/main/java/com/example/parkingsystem/mvp/view/ParkingSpaceReservationView.java
+++ b/app/src/main/java/com/example/parkingsystem/mvp/view/ParkingSpaceReservationView.java
@@ -10,7 +10,6 @@ import com.example.parkingsystem.R;
 import com.example.parkingsystem.databinding.ActivityReservationSpaceParkingBinding;
 import com.example.parkingsystem.mvp.contracts.ParkingSpaceReservationContract;
 import com.example.parkingsystem.mvp.view.base.ActivityView;
-import com.example.parkingsystem.utils.ReservationVerificationResult;
 import java.util.Calendar;
 
 public class ParkingSpaceReservationView extends ActivityView implements ParkingSpaceReservationContract.ParkingSpaceReservationView {
@@ -77,55 +76,86 @@ public class ParkingSpaceReservationView extends ActivityView implements Parking
     }
 
     @Override
-    public int getParkingSpace() {
-        return Integer.parseInt(binding.inputParkingSpaceReservationPlace.getText().toString());
+    public String getParkingSpace() {
+        return binding.inputParkingSpaceReservationPlace.getText().toString();
     }
 
     @Override
-    public int getSecurityCode() {
-        return Integer.parseInt(binding.inputParkingSpaceReservationCode.getText().toString());
+    public String getSecurityCode() {
+        return binding.inputParkingSpaceReservationCode.getText().toString();
     }
 
     @Override
     public void showSaveDone() {
         Context context = getContext();
         Activity activity = getActivity();
-        String message = null;
         if (context != null && activity != null) {
-            message = context.getString(R.string.toast_parking_space_reservation_save);
-            showMessage(context, message);
+            showMessage(context, context.getString(R.string.toast_parking_space_reservation_save));
             activity.finish();
         }
     }
 
     @Override
-    public void showMissingFieldMessage(ReservationVerificationResult reservationVerificationResult) {
+    public void showReleasedPastReservations(int amountReservations) {
         Context context = getContext();
-        String message = null;
         if (context != null) {
-            switch (reservationVerificationResult) {
-                case MISSING_DATE_START:
-                    message = context.getString(R.string.toast_parking_space_reservation_missing_date_start);
-                    break;
-                case MISSING_TIME_START:
-                    message = context.getString(R.string.toast_parking_space_reservation_missing_time_start);
-                    break;
-                case MISSING_DATE_END:
-                    message = context.getString(R.string.toast_parking_space_reservation_missing_date_end);
-                    break;
-                case MISSING_TIME_END:
-                    message = context.getString(R.string.toast_parking_space_reservation_missing_time_end);
-                    break;
-                case MISSING_PARKING_SPACE:
-                    message = context.getString(R.string.toast_parking_space_reservation_missing_place);
-                    break;
-                case MISSING_SECURITY_CODE:
-                    message = context.getString(R.string.toast_parking_space_reservation_missing_security_code);
-                    break;
-                case RESERVATION_OVERLAPPING:
-                    message = context.getString(R.string.toast_parking_space_reservation_reservation_overlapping);
-            }
+            showMessage(context, context.getString(R.string.toast_parking_space_reservation_amount_reserves_released, amountReservations));
         }
-        showMessage(context, message);
+    }
+
+    @Override
+    public void showMissingDateStart() {
+        Context context = getContext();
+        if (context != null) {
+            showMessage(context, context.getString(R.string.toast_parking_space_reservation_missing_date_start));
+        }
+    }
+
+    @Override
+    public void showMissingTimeStart() {
+        Context context = getContext();
+        if (context != null) {
+            showMessage(context, context.getString(R.string.toast_parking_space_reservation_missing_time_start));
+        }
+    }
+
+    @Override
+    public void showMissingDateEnd() {
+        Context context = getContext();
+        if (context != null) {
+            showMessage(context, context.getString(R.string.toast_parking_space_reservation_missing_date_end));
+        }
+    }
+
+    @Override
+    public void showMissingTimeEnd() {
+        Context context = getContext();
+        if (context != null) {
+            showMessage(context, context.getString(R.string.toast_parking_space_reservation_missing_time_end));
+        }
+    }
+
+    @Override
+    public void showMissingParkingSpace() {
+        Context context = getContext();
+        if (context != null) {
+            showMessage(context, context.getString(R.string.toast_parking_space_reservation_missing_place));
+        }
+    }
+
+    @Override
+    public void showMissingSecurityCode() {
+        Context context = getContext();
+        if (context != null) {
+            showMessage(context, context.getString(R.string.toast_parking_space_reservation_missing_security_code));
+        }
+    }
+
+    @Override
+    public void showReservationOverlapping() {
+        Context context = getContext();
+        if (context != null) {
+            showMessage(context, context.getString(R.string.toast_parking_space_reservation_reservation_overlapping));
+        }
     }
 }

--- a/app/src/main/java/com/example/parkingsystem/utils/Constants.java
+++ b/app/src/main/java/com/example/parkingsystem/utils/Constants.java
@@ -5,6 +5,7 @@ public class Constants {
     public final static String SLASH = "/";
     public final static String TWO_POINTS = ":";
     public final static int ONE = 1;
+    public final static int ZERO = 0;
     public final static int NUMBER_MINUS_ONE = -1;
     public final static String FORMAT_DATE = "dd/MM/yy";
     public final static String FORMAT_TIME = "HH:mm";

--- a/app/src/main/res/layout/activity_reservation_space_parking.xml
+++ b/app/src/main/res/layout/activity_reservation_space_parking.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@drawable/wallpaper_main_background"
@@ -44,17 +43,13 @@
         android:id="@+id/input_parking_space_reservation_place"
         style="@style/InputParkingSpaceReservationPlaceStyle"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:autofillHints=""
-        tools:ignore="LabelFor" />
+        android:layout_height="wrap_content" />
 
     <EditText
         android:id="@+id/input_parking_space_reservation_code"
         style="@style/InputParkingSpaceReservationCodeStyle"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:autofillHints=""
-        tools:ignore="LabelFor" />
+        android:layout_height="wrap_content" />
 
     <Button
         android:id="@+id/button_parking_space_reservation_save"
@@ -62,4 +57,11 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/button_parking_space_reservation_save" />
+
+    <Button
+        android:id="@+id/button_parking_space_reservation_delete"
+        style="@style/ButtonParkingSpaceReservationDeleteStyle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/button_parking_space_reservation_delete" />
 </RelativeLayout>

--- a/app/src/main/res/layout/dialog_parking_configure.xml
+++ b/app/src/main/res/layout/dialog_parking_configure.xml
@@ -19,9 +19,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/title_fragment_dialog"
-        android:autofillHints=""
-        android:inputType="number"
-        tools:ignore="LabelFor" />
+        android:inputType="number" />
 
     <Button
         android:id="@+id/button_dialog_fragment_confirm"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -24,4 +24,6 @@
     <string name="toast_parking_space_reservation_missing_place">Please, put the parking place in the field</string>
     <string name="toast_parking_space_reservation_missing_security_code">Please, put the security code in the field</string>
     <string name="toast_parking_space_reservation_reservation_overlapping">This date has already booked. Please select another date</string>
+    <string name="button_parking_space_reservation_delete">DELETE</string>
+    <string name="toast_parking_space_reservation_amount_reserves_released">%1$d reserves have been released</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -54,7 +54,7 @@
         <item name="android:hint">@string/input_parking_space_reservation_place_hint</item>
         <item name="android:inputType">number</item>
     </style>
-    
+
     <style name="InputParkingSpaceReservationCodeStyle">
         <item name="android:layout_below">@id/input_parking_space_reservation_place</item>
         <item name="android:hint">@string/input_parking_space_reservation_code_hint</item>
@@ -68,6 +68,11 @@
 
     <style name="ButtonParkingSpaceReservationSaveStyle">
         <item name="android:layout_below">@+id/input_parking_space_reservation_code</item>
+        <item name="android:layout_centerHorizontal">true</item>
+    </style>
+
+    <style name="ButtonParkingSpaceReservationDeleteStyle">
+        <item name="android:layout_below">@+id/button_parking_space_reservation_save</item>
         <item name="android:layout_centerHorizontal">true</item>
     </style>
 </resources>


### PR DESCRIPTION
- Added button to release past reservations
- The method about this functionality is in the database class

**Folder Structure**
<img width="258" alt="folderStructure" src="https://user-images.githubusercontent.com/84337427/124945808-e015e180-dfe4-11eb-8252-6727e6aa30fe.PNG">

**Database debug**
- The first image contains three saved reservations of which two are past.
<img width="273" alt="BD RESERVATION SAVE" src="https://user-images.githubusercontent.com/84337427/124946121-23705000-dfe5-11eb-8db0-9ca1d3d5f82f.PNG">

- The second shows that these two reserves have been released.
<img width="703" alt="BD RESERVATION RELEASE" src="https://user-images.githubusercontent.com/84337427/124946344-574b7580-dfe5-11eb-982d-748a604af960.PNG">

**Demostration Pixel 3a**
In this I setted a current reservation and a past one.
![GIF PR7 Pixel 3a](https://user-images.githubusercontent.com/84337427/124946673-98dc2080-dfe5-11eb-8c2d-041255a29484.gif)

**Demostration Nexus S**
In this both reservations are old
![GIF PR7 Nexus S](https://user-images.githubusercontent.com/84337427/124946998-db9df880-dfe5-11eb-8dc8-cf2228b0c38a.gif)

